### PR TITLE
Enable error catch for `videoID` not found in `meV` dict.

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -110,7 +110,7 @@ async def stream(search: Search1):
             data in paper['author'] or data in paper['abstract'] or data in paper['id']):
             videoID = str(paper['id'])
 
-    videoLink = meV[videoID]
+    videoLink = meV.get(videoID)
     if videoLink:
         def video(url):
             ydl_opts = {


### PR DESCRIPTION
`meV[videoID]`을 사용할 경우 KeyError가 발생함과 동시에 아래의 에러 처리를 위한 if 문이 동작하지 않지만, `meV.get(videoID)`을 사용함으로써 앞의 문제를 해결할 수 있습니다.